### PR TITLE
Copy-paste error.

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@ config.Formatters.Add(formatter);</code></pre>
 
 	<h2 id="set-generated-file">Set the generated file name with <code>Excel&shy;Document&shy;Attribute</code></h2>
 	<p>With the <code>Excel&shy;Document&shy;Attribute</code>, you can set the file name used for an Excel document generated from a type.</p>
-	<pre><code class="language-csharp">[ExcelDocument("Column header")]
+	<pre><code class="language-csharp">[ExcelDocument("File name")]
 public class ItemType { // ...</code></pre>
 
 	<h2 id="controlling-serialisation-output">Controlling serialisation output with <code>Excel&shy;Column&shy;Attribute</code></h2>


### PR DESCRIPTION
Copied and pasted `ExcelColumn` attribute without changing value.
