### PR TITLE
Issue #28: Fix for EPPlus' AutoFilter bug.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ build/
 [Bb]in/
 [Oo]bj/
 
+# Roslyn cache directories
+*.ide/
+
 # Enable "build/" folder in the NuGet Packages folder since NuGet packages use it for MSBuild targets
 !packages/*/build/
 

--- a/src/WebApiContrib.Formatting.Xlsx/XlsxMediaTypeFormatter.cs
+++ b/src/WebApiContrib.Formatting.Xlsx/XlsxMediaTypeFormatter.cs
@@ -261,7 +261,7 @@ namespace WebApiContrib.Formatting.Xlsx
             var cells = worksheet.Cells[worksheet.Dimension.Address];
 
             // Add autofilter and fit to max column width (if requested).
-            cells.AutoFilter = AutoFilter;
+            if (AutoFilter) cells.AutoFilter = AutoFilter;
             if (AutoFit) cells.AutoFitColumns();
 
             // Set header row where specified.


### PR DESCRIPTION
As reported by eobeda, EPPlus has a bug whereby setting the value of autofilter at all always results in it being true. This fixes that, as suggested in the bug report, by only setting the property if it needs to be set to true.

(Also added Roslyn cache directories to .gitignore.)
