### PR TITLE
fixes #38

### DIFF
--- a/src/WebApiContrib.Formatting.Xlsx/XlsxMediaTypeFormatter.cs
+++ b/src/WebApiContrib.Formatting.Xlsx/XlsxMediaTypeFormatter.cs
@@ -66,7 +66,7 @@ namespace WebApiContrib.Formatting.Xlsx
         /// <param name="cellHeight">Height of each row of data.</param>
         /// <param name="cellStyle">An action method that modifies the worksheet cell style.</param>
         /// <param name="headerStyle">An action method that modifies the cell style of the first (header) row in the worksheet.</param>
-        public XlsxMediaTypeFormatter(bool autoFit = true, bool autoFilter = false, bool freezeHeader = false, double headerHeight = 0, Action<ExcelStyle> cellStyle = null, Action<ExcelStyle> headerStyle = null)
+        public XlsxMediaTypeFormatter(bool autoFit = true, bool autoFilter = false, bool freezeHeader = false, double? headerHeight = null, Action<ExcelStyle> cellStyle = null, Action<ExcelStyle> headerStyle = null)
         {
             SupportedMediaTypes.Clear();
             SupportedMediaTypes.Add(new MediaTypeHeaderValue("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));

--- a/test/WebApiContrib.Formatting.Xlsx.Tests/XlsxMediaTypeFormatterTests.cs
+++ b/test/WebApiContrib.Formatting.Xlsx.Tests/XlsxMediaTypeFormatterTests.cs
@@ -398,6 +398,20 @@ namespace WebApiContrib.Formatting.Xlsx.Tests
         }
 
         [TestMethod]
+        public void XlsxMediaTypeFormatter_WithDefaultHeaderHeight_DefaultsToSameHeightForAllCells()
+        {
+            var data = new[] { new SimpleTestItem { Value1 = "A1", Value2 = "B1" },
+                               new SimpleTestItem { Value1 = "A1", Value2 = "B2" }  };
+
+            var formatter = new XlsxMediaTypeFormatter();
+
+            var sheet = GetWorksheetFromStream(formatter, data);
+
+            Assert.AreNotEqual(sheet.Row(1).Height, 0d, "HeaderHeight should not be zero");
+            Assert.AreEqual(sheet.Row(1).Height, sheet.Row(2).Height, "HeaderHeight should be the same as other rows");
+        }
+
+        [TestMethod]
         public void WriteToStreamAsync_WithCellAndHeaderFormats_WritesFormattedExcelDocumentToStream()
         {
             var data = new[] { new SimpleTestItem { Value1 = "2,1", Value2 = "2,2" },


### PR DESCRIPTION
HeaderHeight is a nullable double on XlsxMediaTypeFormatter, but the
constructor only accepts a non-nullable double. By changing this to nullable
the consumer can now ignore the height and it will use the default. The lack
of this feature only seemed to affect MS Excel. Previously the height was set
to zero, and "hidding" it in MS Excel. Google Spreadsheets seemed unaffected.